### PR TITLE
Remove override from createJSModules

### DIFF
--- a/android/src/main/java/com/rnimmersive/RNImmersivePackage.java
+++ b/android/src/main/java/com/rnimmersive/RNImmersivePackage.java
@@ -17,7 +17,6 @@ public class RNImmersivePackage implements ReactPackage {
     return modules;
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
To make it compatible with React Native 0.47+.
Resolves #5 

See more here: [facebook/react-native@ce6fb33](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8)