### PR TITLE
Crash fix: Tried to access a JS module before the React instance was …

### DIFF
--- a/android/src/main/java/com/rnimmersive/RNImmersiveModule.java
+++ b/android/src/main/java/com/rnimmersive/RNImmersiveModule.java
@@ -71,7 +71,9 @@ public class RNImmersiveModule extends ReactContextBaseJavaModule {
 
   public void emitImmersiveStateChangeEvent() {
     if (_reactContext != null) {
+      if (_reactContext.hasActiveCatalystInstance()) {
       _reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit("@@IMMERSIVE_STATE_CHANGED", null);
+      }
     }
   }
 


### PR DESCRIPTION
I fixed the crash error by adding condition _reactContext.hasActiveCatalystInstance()

Tried to access a JS module before the React instance was fully set up. Calls to ReactContext#getJSModule should only happen once initialize() has been called on your native module.